### PR TITLE
Fix Overriding Minecraft's Default language file

### DIFF
--- a/src/main/resources/assets/minecraft/lang/en_us.json
+++ b/src/main/resources/assets/minecraft/lang/en_us.json
@@ -1,3 +1,0 @@
-{
-  "block.minecraft.bookshelf": "Oak Bookshelf"
-}

--- a/src/main/resources/assets/morebookshelves/lang/en_us.json
+++ b/src/main/resources/assets/morebookshelves/lang/en_us.json
@@ -1,4 +1,6 @@
 {
+  "block.minecraft.bookshelf": "Oak Bookshelf",
+  
   "block.morebookshelves.spruce_bookshelf": "Spruce Bookshelf",
   "block.morebookshelves.birch_bookshelf": "Birch Bookshelf",
   "block.morebookshelves.jungle_bookshelf": "Jungle Bookshelf",


### PR DESCRIPTION
When assembling a modpack for my server, I stumbled into serverside problems similar to https://github.com/P3NG00/OhHowTheCraftingHasTabled/issues/1 (garbling chat, commands output and deaths/advancements). Suffice it so say, a situation like that would not have been convenient for my server (and my group of friends).
When trying to pinpoint the bug, I noticed that the problem did not happen with How The Crafting..., so I started checking the issues and commit history and found the difference.
This PR is basically an adaptation of the part of https://github.com/P3NG00/OhHowTheCraftingHasTabled/commit/6d07394cc657bef95ffd84d5ebaa6676f3cac570 concerning the language files.